### PR TITLE
Updating workflows to support new Dependabot permissions

### DIFF
--- a/.github/workflows/auto-merge-dependencies.yaml
+++ b/.github/workflows/auto-merge-dependencies.yaml
@@ -1,9 +1,7 @@
 name: auto-merge
 
 on:
-  pull_request:
-    types: ['opened', 'synchronize']
-    # branches: ['dependabot/**']
+  pull_request_target:
 
 jobs:
   auto-merge:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,6 @@
 name: Check, Build, and Run
 on:
   pull_request:
-    types: ['opened', 'synchronize']
   push:
     branches:
       - main
@@ -55,12 +54,13 @@ jobs:
         run: |
           echo "$(date): Testing ${GITHUB_SHA}" > test.txt
           echo "static value" > static.txt
-      - name: Run action against test with default token
-        uses: ./
-        with:
-          branch: test
-          message: ':robot: Test commit'
-          glob-patterns: test.txt
+      # TODO: Disabled since forks and dependabot don't have access to a read-write token
+      # - name: Run action against test with default token
+      #   uses: ./
+      #   with:
+      #     branch: test
+      #     message: ':robot: Test commit'
+      #     glob-patterns: test.txt
       - name: Run action against protected-test with admin token
         uses: ./
         with:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updated the testing and auto-approval workflows to be able to pass for Dependabot and fork pull requests.

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Dependabot PRs are now treated as coming from a fork (see [this blog post](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/)). This was causing an issue in the testing and auto-approval workflows since they assumed they were getting a read-write `GITHUB_TOKEN`.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Will be tested by seeing if checks on the current set of Dependabot PRs are passing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] ~My change requires a change to the documentation.~
- [ ] ~I have updated the documentation accordingly.~
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
